### PR TITLE
Twitterログアウト機能を実装する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  helper_method :logged_in?
+
+  private
+
+  def logged_in?
+    !!session[:user_id]
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,4 +4,9 @@ class SessionsController < ApplicationController
     session[:user_id] = user.id
     redirect_to root_path, notice: 'ログインしました'
   end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: 'ログアウトしました'
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    reset_session
+    session[:user_id] = nil
     redirect_to root_path, notice: 'ログアウトしました'
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,11 @@
         </button>
         <div class='collapse navbar-collapse justify-content-end' id='bs-example-navbar-collapse-1'>
           <ul class='navbar-nav'>
-            <li class='nav-item'><%= link_to 'Twitterでログイン', '/auth/twitter', class: 'nav-link' %></li>
+            <% if logged_in? %>
+              <li class='nav-item'><%= link_to 'ログアウト', logout_path, class: 'nav-link' %></li>
+            <% else %>
+              <li class='nav-item'><%= link_to 'Twitterでログイン', '/auth/twitter', class: 'nav-link' %></li>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
+  get '/logout' => 'sessions#destroy', as: :logout
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,12 +55,4 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   OmniAuth.config.test_mode = true
-  OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
-    provider: 'twitter',
-    uid: '1234567890',
-    info: {
-      nickname: 'hogehoge',
-      image: 'http://image.example.com',
-    },
-  )
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,5 +54,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.order = 'random'
   OmniAuth.config.test_mode = true
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,4 +55,12 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
+    provider: 'twitter',
+    uid: '1234567890',
+    info: {
+      nickname: 'hogehoge',
+      image: 'http://image.example.com',
+    },
+  )
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -51,4 +51,20 @@ RSpec.describe SessionsController, type: :request do
       end
     end
   end
+
+  describe '#destroy' do
+    subject { get '/logout' }
+
+    before { get '/auth/twitter/callback' }
+
+    it 'sessionのIDが削除されていること' do
+      subject
+      expect(session[:user_id]).to be_nil
+    end
+
+    it 'ログアウト後トップページにリダイレクトすること' do
+      subject
+      expect(response).to redirect_to root_path
+    end
+  end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe SessionsController, type: :request do
+  before do
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
+      provider: 'twitter',
+      uid: '1234567890',
+      info: {
+        nickname: 'hogehoge',
+        image: 'http://image.example.com',
+      },
+    )
+  end
+
   describe '#create' do
     subject { get '/auth/twitter/callback' }
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -4,17 +4,6 @@ RSpec.describe SessionsController, type: :request do
   describe '#create' do
     subject { get '/auth/twitter/callback' }
 
-    before do
-      OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
-        provider: 'twitter',
-        uid: '1234567890',
-        info: {
-          nickname: 'hogehoge',
-          image: 'http://image.example.com',
-        },
-      )
-    end
-
     context 'ユーザが未登録の場合' do
       it 'ユーザを新規作成すること' do
         get '/auth/twitter'


### PR DESCRIPTION
やったこと
---
- ログアウト処理の作成
  - SessionController に destroy アクションを追加
  - ビューにログアウト用のリンクを追加
  - ログイン状態を判別する logged_in? メソッドの実装
  - ログアウト用のルーティングを追加
- ログアウト処理のテストを作成
  - request spec にて destroy アクションのテストを作成
  - omniauth のモックの設定を rails_helper に移動

動作確認
---
1. `$ rails s`でサーバーを起動する
2. ブラウザから`http://lvh.me:3000/`にアクセスする
3. 右上の「Twitterでログイン」のリンクをクリック
4. Twitterのアプリケーション認証ページで「認証」のボタンをクリック
5. トップページにリダイレクトされるので 右上の「ログアウト」のリンクをクリック
6. 以下の画面のように「ログアウトしました」というフラッシュが表示される
<img width="1279" alt="screen shot 2018-05-23 at 17 25 01" src="https://user-images.githubusercontent.com/35087200/40412435-4bbca8b2-5eae-11e8-9c48-908ff03411a1.png">