### PR TITLE
イベント登録機能を実装する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -266,9 +266,10 @@ Rails/SkipsModelValidations:
 Rails/Validation:
   Enabled: false
 
-# 双方向の関連付けを明示する inverse_of はアプリの仕様によって要否が変わるので、無効にしておく。
+# 双方向の関連付けを明示する inverse_of は:throughオプション、:polymorphicオプション、:asオプションとの併用ができないため、アプリの仕様によってつけるかどうかを選択できるよう無効にしておく。
 #
 # @see https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/InverseOf
+# @see https://railsguides.jp/association_basics.html#%E5%8F%8C%E6%96%B9%E5%90%91%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91
 #
 Rails/InverseOf:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -266,7 +266,7 @@ Rails/SkipsModelValidations:
 Rails/Validation:
   Enabled: false
 
-# Rails4.1 以降ではデフォルトで inverse_of が設定されているため無効にする。
+# 双方向の関連付けを明示する inverse_of はアプリの仕様によって要否が変わるので、無効にしておく。
 #
 # @see https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/InverseOf
 #

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -265,3 +265,10 @@ Rails/SkipsModelValidations:
 #
 Rails/Validation:
   Enabled: false
+
+# Rails4.1 以降ではデフォルトで inverse_of が設定されているため無効にする。
+#
+# @see https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/InverseOf
+#
+Rails/InverseOf:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-doc'
   gem 'pry-rails'
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'shoulda-matchers'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'rubocop'
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -244,6 +246,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.0)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -243,6 +247,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.0)
+  rails-controller-testing
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/events.coffee
+++ b/app/assets/javascripts/events.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,19 @@
 class ApplicationController < ActionController::Base
-  helper_method :logged_in?
+  helper_method :current_user, :logged_in?
 
   private
 
+  def current_user
+    return unless session[:user_id]
+    @current_user ||= User.find(session[:user_id])
+  end
+
   def logged_in?
     !!session[:user_id]
+  end
+
+  def authenticate
+    return if logged_in?
+    redirect_to root_path, alert: 'ログインしてください'
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,2 @@
+class EventsController < ApplicationController
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,22 @@
 class EventsController < ApplicationController
+  before_action :authenticate
+
+  def new
+    @event = current_user.created_events.build
+  end
+
+  def create
+    @event = current_user.created_events.build(event_params)
+    if @event.save
+      redirect_to @event, notice: '作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:name, :place, :content, :start_time, :end_time)
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  belongs_to :owner, class_name: 'User'
+
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,16 @@
 class Event < ApplicationRecord
+  validates :name, length: { maximum: 50 }, presence: true
+  validates :place, length: { maximum: 100 }, presence: true
+  validates :content, length: { maximum: 2000 }, presence: true
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+  validate :end_time_should_be_after_start_time
+
+  private
+
+  def end_time_should_be_after_start_time
+    return unless start_time && end_time
+
+    errors.add(:end_time, 'は開始時間よりも後に設定してください') if end_time <= start_time
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+
   def self.find_or_create_from_auth_hash(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,48 @@
+<% now = Time.zone.now %>
+
+<div class='page-header'>
+  <h1>イベント作成</h1>
+</div>
+
+<%= form_for(@event, role: 'form') do |f| %>
+  <% if @event.errors.any? %>
+    <div class='alert alert-danger'>
+      <ul>
+        <% @event.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class='form-group'>
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control', autofocus: true %>
+  </div>
+
+  <div class='form-group'>
+    <%= f.label :place %>
+    <%= f.text_field :place, class: 'form-control' %>
+  </div>
+
+  <div class='form-group'>
+    <%= f.label :start_time %>
+    <div>
+      <%= f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+
+  <div class='form-group'>
+    <%= f.label :end_time %>
+    <div>
+      <%= f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+
+  <div class='form-group'>
+    <%= f.label :content %>
+    <%= f.text_area :content, class: 'form-control', row: 10 %>
+  </div>
+
+  <%= f.submit '作成', class: 'btn btn-secondary', data: { disable_with: '作成中…' } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,11 @@
           <%= flash[:notice] %>
         </div>
       <% end %>
+      <% if flash[:alert] %>
+        <div class='alert alert-danger'>
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
         </button>
         <div class='collapse navbar-collapse justify-content-end' id='bs-example-navbar-collapse-1'>
           <ul class='navbar-nav'>
+            <li class='nav-item'><%= link_to 'イベントを作る', new_event_path, class: 'nav-link' %></li>
             <% if logged_in? %>
               <li class='nav-item'><%= link_to 'ログアウト', logout_path, class: 'nav-link' %></li>
             <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,7 @@ module PerfectRailsAwesomeEvents
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module PerfectRailsAwesomeEvents
     config.generators.system_tests = nil
 
     config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ar_ja.yml
+++ b/config/locales/ar_ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      event: イベント
+    attributes:
+      event:
+        name: 名前
+        place: 場所
+        start_time: 開始時間
+        end_time: 終了時間
+        content: 内容

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,205 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :events
   root to: 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
-  resources :events
   root to: 'welcome#index'
+
+  resources :events
+
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout
 end

--- a/db/migrate/20180525054758_create_events.rb
+++ b/db/migrate/20180525054758_create_events.rb
@@ -2,13 +2,15 @@ class CreateEvents < ActiveRecord::Migration[5.2]
   def change
     create_table :events do |t|
       t.integer :owner_id
-      t.string :name
-      t.string :place
-      t.datetime :start_time
-      t.datetime :end_time
-      t.text :content
+      t.string :name, null: false
+      t.string :place, null: false
+      t.datetime :start_time, null: false
+      t.datetime :end_time, null: false
+      t.text :content, null: false
 
       t.timestamps
     end
+
+    add_index :events, :owner_id
   end
 end

--- a/db/migrate/20180525054758_create_events.rb
+++ b/db/migrate/20180525054758_create_events.rb
@@ -1,0 +1,14 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.integer :owner_id
+      t.string :name
+      t.string :place
+      t.datetime :start_time
+      t.datetime :end_time
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_180_516_054_408) do
+ActiveRecord::Schema.define(version: 20_180_525_054_758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
+
+  create_table 'events', force: :cascade do |t|
+    t.integer 'owner_id'
+    t.string 'name', null: false
+    t.string 'place', null: false
+    t.datetime 'start_time', null: false
+    t.datetime 'end_time', null: false
+    t.text 'content', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['owner_id'], name: 'index_events_on_owner_id'
+  end
 
   create_table 'users', force: :cascade do |t|
     t.string 'provider', null: false

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe EventsController, type: :controller do
-end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :event do
+    owner_id 1
+    name 'MyString'
+    place 'MyString'
+    start_time '2018-05-25 14:47:58'
+    end_time '2018-05-25 14:47:58'
+    content 'MyText'
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :event do
-    owner_id 1
-    name 'MyString'
-    place 'MyString'
-    start_time '2018-05-25 14:47:58'
-    end_time '2018-05-25 14:47:58'
-    content 'MyText'
+    owner
+    sequence(:name) { |i| "イベント名#{i}" }
+    sequence(:place) { |i| "イベント開催場所#{i}" }
+    sequence(:content) { |i| "イベント内容#{i}" }
+    start_time { rand(1..30).days.from_now }
+    end_time { start_time + rand(1..30).hours }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user do
+  factory :user, aliases: [:owner] do
     provider 'twitter'
     uid '1234567890'
     nickname 'hogehoge'

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the EventsHelper. For example:
+#
+# describe EventsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe EventsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#name' do
+    it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_most(50) }
+  end
+
+  describe '#place' do
+    it { should validate_presence_of(:place) }
+    it { should validate_length_of(:place).is_at_most(100) }
+  end
+
+  describe '#content' do
+    it { should validate_presence_of(:content) }
+    it { should validate_length_of(:content).is_at_most(2000) }
+  end
+
+  describe '#start_time' do
+    it { should validate_presence_of(:start_time) }
+  end
+
+  describe '#end_time' do
+    it { should validate_presence_of(:end_time) }
+  end
+
+  describe '#end_time_should_be_after_start_time' do
+    context 'end_time が start_time より後の場合' do
+      let(:valid_event) { build(:event, start_time: Time.zone.now, end_time: Time.zone.now + 1.hour) }
+
+      it 'event が有効であること' do
+        expect(valid_event).to be_valid
+      end
+    end
+
+    context 'end_time が start_time より前の場合' do
+      let(:invalid_event) { build(:event, start_time: Time.zone.now, end_time: Time.zone.now - 1.hour) }
+
+      it 'event が無効でありエラーが発生すること' do
+        expect(invalid_event).to be_invalid
+        expect(invalid_event.errors[:end_time]).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -36,9 +36,8 @@ RSpec.describe Event, type: :model do
     context 'end_time が start_time より前の場合' do
       let(:invalid_event) { build(:event, start_time: Time.zone.now, end_time: Time.zone.now - 1.hour) }
 
-      it 'event が無効でありエラーが発生すること' do
+      it 'event が無効であること' do
         expect(invalid_event).to be_invalid
-        expect(invalid_event.errors[:end_time]).to be_present
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,13 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -43,9 +43,7 @@ RSpec.describe EventsController, type: :request do
     before { get '/auth/twitter/callback' }
 
     context '正しい値が入力された場合' do
-      let(:event_params) do
-        { event: attributes_for(:event) }
-      end
+      let(:event_params) { { event: attributes_for(:event) } }
 
       it 'イベントが新規作成される' do
         expect { subject }.to change { Event.count }.by(1)
@@ -59,9 +57,7 @@ RSpec.describe EventsController, type: :request do
     end
 
     context '正しい値が入力されなかった場合' do
-      let(:event_params) do
-        { event: attributes_for(:event).merge(name: '') }
-      end
+      let(:event_params) { { event: attributes_for(:event).merge(name: '') } }
 
       it 'イベントが作成されないこと' do
         expect { subject }.not_to change { Event.count }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :request do
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe EventsController, type: :request do
     context '正しい値が入力された場合' do
       let(:event_params) { { event: attributes_for(:event) } }
 
-      it 'イベントが新規作成される' do
+      it 'イベントが新規作成されること' do
         expect { subject }.to change { Event.count }.by(1)
       end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,4 +1,76 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :request do
+  before do
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
+      provider: 'twitter',
+      uid: '1234567890',
+      info: {
+        nickname: 'hogehoge',
+        image: 'http://image.example.com',
+      },
+    )
+  end
+
+  describe '#new' do
+    subject { get '/events/new' }
+
+    context 'ログイン済みのユーザがアクセスした場合' do
+      before { get '/auth/twitter/callback' }
+
+      it 'イベント作成ページが表示されること' do
+        subject
+        expect(response).to render_template('new')
+      end
+    end
+
+    context '未ログインのユーザがアクセスした場合' do
+      it 'トップページへリダイレクトされること' do
+        subject
+        expect(response).to redirect_to root_path
+      end
+
+      it 'アラートが表示されること' do
+        subject
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe '#create' do
+    subject { post '/events', params: event_params }
+
+    before { get '/auth/twitter/callback' }
+
+    context '正しい値が入力された場合' do
+      let(:event_params) do
+        { event: attributes_for(:event) }
+      end
+
+      it 'イベントが新規作成される' do
+        expect { subject }.to change { Event.count }.by(1)
+      end
+
+      it 'events/:id にリダイレクトされること' do
+        subject
+        event_id = Event.last.id
+        expect(response).to redirect_to("/events/#{event_id}")
+      end
+    end
+
+    context '正しい値が入力されなかった場合' do
+      let(:event_params) do
+        { event: attributes_for(:event).merge(name: '') }
+      end
+
+      it 'イベントが作成されないこと' do
+        expect { subject }.not_to change { Event.count }
+      end
+
+      it 'イベント作成ページが再度表示されること' do
+        subject
+        expect(response).to render_template('new')
+      end
+    end
+  end
 end


### PR DESCRIPTION
やったこと
---
- タイムゾーンの設定
- Event モデルを作成
  - モデルとコントローラとルーティングを作成
  - Event モデルに NOT NULL制約とインデックスを追加
  - Event モデルの各属性にバリデーションを追加
- ビューのヘッダーに「イベントを作る」リンクを追加
- ログイン状態を管理する処理を作成
  - ApplicationController にログイン周りの処理をするメソッド `current_user` と `authenticate` を追加
  - `authenticate` メソッドでトップページにリダイレクトした時のアラートメッセージをビューに追加
  - EventsController に `create` アクションと `new` アクションを追加
  - User モデルにアソシエーションを追加
- イベント登録用のフォームを作成
- `i18n` の設定
- Event モデルのバリデーションテストを作成
  - Event 用の factory_bot を定義
  - `shoulda-matchers` の導入
- request spec にて EventsController のテストを追加
  - `rails-controller-testing` のインストール


動作確認
---
1. `$ rails s` でサーバーを起動する
2. ブラウザから `http://lvh.me:3000/` にアクセスする
3. 右上の「Twitterでログイン」のリンクをクリック
4. 右上の「イベントを作る」リンクをクリック
5. 何も入力せずに、作成ボタンを押し、以下の画面1のようにエラーメッセージが表示されることを確認する
6. 全ての項目に正しい値を入力し、作成ボタンを押すと以下の画面2のように `Unknown action` のエラーページが表示されることを確認する

画面1
<img width="1279" alt="screen shot 2018-05-29 at 11 50 46" src="https://user-images.githubusercontent.com/35087200/40635942-a0733c76-6337-11e8-9457-3d68ef7df9b7.png">

画面2
<img width="1279" alt="screen shot 2018-05-29 at 11 51 58" src="https://user-images.githubusercontent.com/35087200/40635957-abb398e2-6337-11e8-8ae0-de6e85672cfb.png">



その他
---
- modelのバリデーションのテストにのみ、 `shoulda-matchers` を使っています。
-  6c4080c パRails的には次節の内容ですが、`FactoryBot` の `aliases` を使うため、こちらでEventモデルにアソシエーションを追加しています。